### PR TITLE
config -> setting within SessionAuth 2FA action check 

### DIFF
--- a/src/Filters/SessionAuth.php
+++ b/src/Filters/SessionAuth.php
@@ -45,7 +45,7 @@ class SessionAuth implements FilterInterface
         // ensure they must finish it first.
         $identity = auth('session')->user()->getIdentity('email_2fa');
         if ($identity instanceof UserIdentity) {
-            $action = config('Auth')->actions['login'];
+            $action = setting('Auth.actions')['login'];
 
             if ($action) {
                 session()->set('auth_action', $action);


### PR DESCRIPTION
Action within `SessionAuth` should use setting helper, because config will be always `null`.