### PR TITLE
test: fix AuthenticationTest

### DIFF
--- a/src/Authentication/Authentication.php
+++ b/src/Authentication/Authentication.php
@@ -49,6 +49,8 @@ class Authentication
 
         $className = $this->config->authenticators[$handler];
 
+        assert($this->userProvider !== null, '$userProvider must be set.');
+
         $this->instances[$handler] = new $className($this->userProvider);
 
         return $this->instances[$handler];

--- a/tests/Authentication/AuthenticationTest.php
+++ b/tests/Authentication/AuthenticationTest.php
@@ -2,10 +2,12 @@
 
 namespace Tests\Authentication;
 
+use CodeIgniter\Test\DatabaseTestTrait;
 use Sparks\Shield\Authentication\Authentication;
 use Sparks\Shield\Authentication\AuthenticationException;
 use Sparks\Shield\Authentication\Handlers\Session;
 use Sparks\Shield\Config\Auth;
+use Sparks\Shield\Models\UserModel;
 use Tests\Support\TestCase;
 
 /**
@@ -13,7 +15,10 @@ use Tests\Support\TestCase;
  */
 final class AuthenticationTest extends TestCase
 {
+    use DatabaseTestTrait;
+
     protected Authentication $auth;
+    protected $namespace = ['CodeIgniter\Settings', '\Sparks\Shield'];
 
     protected function setUp(): void
     {
@@ -21,6 +26,7 @@ final class AuthenticationTest extends TestCase
 
         $config     = new Auth();
         $this->auth = new Authentication($config);
+        $this->auth->setProvider(new UserModel());
     }
 
     public function testThrowsOnUnknownHandler()


### PR DESCRIPTION
```
$ vendor/bin/phpunit tests/Authentication/AuthenticationTest.php
PHPUnit 9.5.20 #StandWithUkraine

Runtime:       PHP 8.0.18
Configuration: /Users/kenji/work/codeigniter/codeigniter-shield/phpunit.xml
Random Seed:   1650351079

EE                                                                  2 / 2 (100%)

Time: 00:00.080, Memory: 12.00 MB

There were 2 errors:

1) Tests\Authentication\AuthenticationTest::testThrowsOnUnknownHandler
ErrorException: SQLite3::query(): Unable to prepare statement: 1, no such table: db_settings

/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/framework/system/Database/SQLite3/Connection.php:116
/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/framework/system/Database/BaseConnection.php:670
/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/framework/system/Database/BaseConnection.php:598
/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/framework/system/Database/BaseBuilder.php:1455
/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/settings/src/Handlers/DatabaseHandler.php:163
/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/settings/src/Handlers/DatabaseHandler.php:41
/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/settings/src/Handlers/DatabaseHandler.php:75
/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/settings/src/Settings.php:84
/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/settings/src/Helpers/setting_helper.php:25
/Users/kenji/work/codeigniter/codeigniter-shield/tests/_support/TestCase.php:21
/Users/kenji/work/codeigniter/codeigniter-shield/tests/Authentication/AuthenticationTest.php:20

2) Tests\Authentication\AuthenticationTest::testFactoryLoadsDefault
ErrorException: SQLite3::query(): Unable to prepare statement: 1, no such table: db_settings

/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/framework/system/Database/SQLite3/Connection.php:116
/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/framework/system/Database/BaseConnection.php:670
/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/framework/system/Database/BaseConnection.php:598
/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/framework/system/Database/BaseBuilder.php:1455
/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/settings/src/Handlers/DatabaseHandler.php:163
/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/settings/src/Handlers/DatabaseHandler.php:41
/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/settings/src/Handlers/DatabaseHandler.php:75
/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/settings/src/Settings.php:84
/Users/kenji/work/codeigniter/codeigniter-shield/vendor/codeigniter4/settings/src/Helpers/setting_helper.php:25
/Users/kenji/work/codeigniter/codeigniter-shield/tests/_support/TestCase.php:21
/Users/kenji/work/codeigniter/codeigniter-shield/tests/Authentication/AuthenticationTest.php:20

ERRORS!
Tests: 2, Assertions: 0, Errors: 2.
```
