### PR TITLE
refactor: remove BaseValidator::setConfig()

### DIFF
--- a/src/Authentication/Passwords.php
+++ b/src/Authentication/Passwords.php
@@ -96,8 +96,7 @@ class Passwords
         }
 
         foreach ($this->config->passwordValidators as $className) {
-            $class = new $className();
-            $class->setConfig($this->config);
+            $class = new $className($this->config);
 
             $result = $class->check($password, $user);
             if (! $result->isOk()) {

--- a/src/Authentication/Passwords/BaseValidator.php
+++ b/src/Authentication/Passwords/BaseValidator.php
@@ -6,22 +6,13 @@ use Sparks\Shield\Config\Auth as AuthConfig;
 
 class BaseValidator
 {
-    protected ?AuthConfig $config = null;
+    protected AuthConfig $config;
     protected ?string $error      = null;
     protected ?string $suggestion = null;
 
-    /**
-     * Allows for setting a config file on the Validator.
-     *
-     * @param AuthConfig $config
-     *
-     * @return $this
-     */
-    public function setConfig($config)
+    public function __construct(AuthConfig $config)
     {
         $this->config = $config;
-
-        return $this;
     }
 
     /**

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -5,7 +5,6 @@ namespace Sparks\Shield\Controllers;
 use App\Controllers\BaseController;
 use CodeIgniter\Events\Events;
 use Sparks\Shield\Entities\User;
-use Sparks\Shield\Models\UserModel;
 
 /**
  * Class RegisterController
@@ -97,7 +96,7 @@ class RegisterController extends BaseController
      */
     protected function getUserProvider()
     {
-        return model(setting('Auth.userProvider')); 
+        return model(setting('Auth.userProvider'));
     }
 
     /**

--- a/tests/Unit/CompositionValidatorTest.php
+++ b/tests/Unit/CompositionValidatorTest.php
@@ -22,8 +22,7 @@ final class CompositionValidatorTest extends TestCase
         $this->config                        = new Auth();
         $this->config->minimumPasswordLength = 8;
 
-        $this->validator = new CompositionValidator();
-        $this->validator->setConfig($this->config);
+        $this->validator = new CompositionValidator($this->config);
     }
 
     public function testCheckThrowsException()
@@ -33,7 +32,6 @@ final class CompositionValidatorTest extends TestCase
 
         $password                            = '1234';
         $this->config->minimumPasswordLength = 0;
-        $this->validator->setConfig($this->config);
 
         $this->validator->check($password);
     }

--- a/tests/Unit/DictionaryValidatorTest.php
+++ b/tests/Unit/DictionaryValidatorTest.php
@@ -19,8 +19,7 @@ final class DictionaryValidatorTest extends CIUnitTestCase
 
         $config = new AuthConfig();
 
-        $this->validator = new DictionaryValidator();
-        $this->validator->setConfig($config);
+        $this->validator = new DictionaryValidator($config);
     }
 
     public function testCheckFalseOnFoundPassword()

--- a/tests/Unit/NothingPersonalValidatorTest.php
+++ b/tests/Unit/NothingPersonalValidatorTest.php
@@ -18,10 +18,8 @@ final class NothingPersonalValidatorTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $config = new Auth();
-
-        $this->validator = new NothingPersonalValidator();
-        $this->validator->setConfig($config);
+        $config          = new Auth();
+        $this->validator = new NothingPersonalValidator($config);
     }
 
     public function testFalseOnPasswordIsEmail()
@@ -80,7 +78,7 @@ final class NothingPersonalValidatorTest extends CIUnitTestCase
             'firstname',
             'lastname',
         ];
-        $this->validator->setConfig($config);
+        $this->validator = new NothingPersonalValidator($config);
 
         $user = new User([
             'email'     => 'jsmith@example.com',
@@ -120,7 +118,7 @@ final class NothingPersonalValidatorTest extends CIUnitTestCase
 
         $config                = new Auth();
         $config->maxSimilarity = 50;
-        $this->validator->setConfig($config);
+        $this->validator       = new NothingPersonalValidator($config);
 
         $isNotPersonal = $this->getPrivateMethodInvoker($this->validator, 'isNotPersonal');
 
@@ -158,7 +156,7 @@ final class NothingPersonalValidatorTest extends CIUnitTestCase
             'firstname',
             'lastname',
         ];
-        $this->validator->setConfig($config);
+        $this->validator = new NothingPersonalValidator($config);
 
         $user = new User([
             'username'  => 'Vlad the Impaler',
@@ -210,7 +208,7 @@ final class NothingPersonalValidatorTest extends CIUnitTestCase
     {
         $config                = new Auth();
         $config->maxSimilarity = $maxSimilarity;
-        $this->validator->setConfig($config);
+        $this->validator       = new NothingPersonalValidator($config);
 
         $user = new User([
             'username' => 'CaptainJoe',

--- a/tests/Unit/PwnedValidatorTest.php
+++ b/tests/Unit/PwnedValidatorTest.php
@@ -8,6 +8,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 use Sparks\Shield\Authentication\AuthenticationException;
 use Sparks\Shield\Authentication\Passwords\PwnedValidator;
+use Sparks\Shield\Config\Auth as AuthConfig;
 use Sparks\Shield\Config\Services;
 
 /**
@@ -26,7 +27,7 @@ final class PwnedValidatorTest extends CIUnitTestCase
 
         Services::reset();
 
-        $this->validator = new PwnedValidator();
+        $this->validator = new PwnedValidator(new AuthConfig());
     }
 
     public function testCheckFalseOnPwnedPassword()


### PR DESCRIPTION
`ValidatorInterface` does not have `setConfig()`.

All Validator classes require the Config and there is no necessity to set it later.
