### PR TITLE
refactor: use Interface methods

### DIFF
--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -25,7 +25,7 @@ class Email2FA implements ActionInterface
 
         // Delete any previous activation identities
         $identities = new UserIdentityModel();
-        $identities->where('user_id', $user->id)
+        $identities->where('user_id', $user->getAuthId())
             ->where('type', 'email_2fa')
             ->delete();
 
@@ -34,7 +34,7 @@ class Email2FA implements ActionInterface
         $code = random_string('nozero', 6);
 
         $identities->insert([
-            'user_id' => $user->id,
+            'user_id' => $user->getAuthId(),
             'type'    => 'email_2fa',
             'secret'  => $code,
             'name'    => 'login',
@@ -56,12 +56,12 @@ class Email2FA implements ActionInterface
         $email = $request->getPost('email');
         $user  = auth()->user();
 
-        if (empty($email) || $email !== $user->email) {
+        if (empty($email) || $email !== $user->getAuthEmail()) {
             return redirect()->route('auth-action-show')->with('error', lang('Auth.invalidEmail'));
         }
 
         $identities = new UserIdentityModel();
-        $identity   = $identities->where('user_id', $user->id)
+        $identity   = $identities->where('user_id', $user->getAuthId())
             ->where('type', 'email_2fa')
             ->first();
 
@@ -73,7 +73,7 @@ class Email2FA implements ActionInterface
         helper('email');
         $email = emailer();
         $email->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '')
-            ->setTo($user->email)
+            ->setTo($user->getAuthEmail())
             ->setSubject(lang('Auth.email2FASubject'))
             ->setMessage(view(setting('Auth.views')['action_email_2fa_email'], ['code' => $identity->secret]))
             ->send();
@@ -101,7 +101,7 @@ class Email2FA implements ActionInterface
 
         // On success - remove the identity and clean up session
         model(UserIdentityModel::class)
-            ->where('user_id', $user->id)
+            ->where('user_id', $user->getAuthId())
             ->where('type', 'email_2fa')
             ->delete();
 

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -22,7 +22,7 @@ class EmailActivator implements ActionInterface
 
         // Delete any previous activation identities
         $identities = new UserIdentityModel();
-        $identities->where('user_id', $user->id)
+        $identities->where('user_id', $user->getAuthId())
             ->where('type', 'email_activate')
             ->delete();
 
@@ -31,7 +31,7 @@ class EmailActivator implements ActionInterface
         $code = random_string('nozero', 6);
 
         $identities->insert([
-            'user_id' => $user->id,
+            'user_id' => $user->getAuthId(),
             'type'    => 'email_activate',
             'secret'  => $code,
             'name'    => 'register',
@@ -42,7 +42,7 @@ class EmailActivator implements ActionInterface
         helper('email');
         $email = emailer();
         $email->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '')
-            ->setTo($user->email)
+            ->setTo($user->getAuthEmail())
             ->setSubject(lang('Auth.emailActivateSubject'))
             ->setMessage(view(setting('Auth.views')['action_email_activate_email'], ['code' => $code]))
             ->send();

--- a/src/Authentication/Handlers/Session.php
+++ b/src/Authentication/Handlers/Session.php
@@ -8,6 +8,7 @@ use Exception;
 use InvalidArgumentException;
 use Sparks\Shield\Authentication\AuthenticationException;
 use Sparks\Shield\Authentication\AuthenticatorInterface;
+use Sparks\Shield\Authentication\Passwords;
 use Sparks\Shield\Entities\User;
 use Sparks\Shield\Interfaces\Authenticatable;
 use Sparks\Shield\Models\LoginModel;
@@ -116,6 +117,7 @@ class Session implements AuthenticatorInterface
         }
 
         // Now, try matching the passwords.
+        /** @var Passwords $passwords */
         $passwords = service('passwords');
 
         if (! $passwords->verify($givenPassword, $user->password_hash)) {

--- a/tests/Authentication/ChainFilterTest.php
+++ b/tests/Authentication/ChainFilterTest.php
@@ -72,7 +72,7 @@ final class ChainFilterTest extends TestCase
         $result->assertSee('Protected');
 
         $this->assertSame($this->user->id, auth()->id());
-        $this->assertSame($this->user->id, auth()->user()->id);
+        $this->assertSame($this->user->id, auth()->user()->getAuthId());
     }
 
     public function testFilterSuccessTokens()
@@ -86,7 +86,7 @@ final class ChainFilterTest extends TestCase
         $result->assertSee('Protected');
 
         $this->assertSame($this->user->id, auth()->id());
-        $this->assertSame($this->user->id, auth()->user()->id);
+        $this->assertSame($this->user->id, auth()->user()->getAuthId());
 
         // User should have the current token set.
         $this->assertInstanceOf(AccessToken::class, auth('tokens')->user()->currentAccessToken());

--- a/tests/Authentication/SessionFilterTest.php
+++ b/tests/Authentication/SessionFilterTest.php
@@ -68,7 +68,7 @@ final class SessionFilterTest extends DatabaseTestCase
         $result->assertSee('Protected');
 
         $this->assertSame($user->id, auth('session')->id());
-        $this->assertSame($user->id, auth('session')->user()->id);
+        $this->assertSame($user->id, auth('session')->user()->getAuthId());
         // Last Active should have been updated
         $this->assertNotEmpty(auth('session')->user()->last_active);
     }

--- a/tests/Authentication/TokenFilterTest.php
+++ b/tests/Authentication/TokenFilterTest.php
@@ -71,7 +71,7 @@ final class TokenFilterTest extends DatabaseTestCase
         $result->assertSee('Protected');
 
         $this->assertSame($user->id, auth('tokens')->id());
-        $this->assertSame($user->id, auth('tokens')->user()->id);
+        $this->assertSame($user->id, auth('tokens')->user()->getAuthId());
 
         // User should have the current token set.
         $this->assertInstanceOf(AccessToken::class, auth('tokens')->user()->currentAccessToken());


### PR DESCRIPTION
- use Interface methods instead of methods in concrete classes

Fixes 12 errors of 35: https://github.com/lonnieezell/codeigniter-shield/pull/44#issuecomment-1105787493